### PR TITLE
feat(blob): Blob<T> -> Blob<isize>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phloem"
 description = "Blob for Machine Learning"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Michael Hirn <mj@autumnai.com>"]
 repository = "https://github.com/autumnai/phloem"
 homepage = "https://github.com/autumnai/phloem"

--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/autumnai/phloem?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![Build Status](https://travis-ci.org/autumnai/phloem.svg?branch=master)](https://travis-ci.org/autumnai/phloem)
 
 See the [Documentation](http://autumnai.github.io/phloem)
+
+Phloem exposes a universal/numeric Blob for machine learning purposes.
+This might be used with the Rust Machine Learning Framework
+[leaf](https://github.com/autumnai/leaf)

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -4,21 +4,21 @@
 
 #[derive(Debug)]
 /// The Container for the `data` Vec, its `diff` and its `shape` dimensions
-pub struct Blob<T> {
-    data: Vec<T>,
-    diff: Vec<T>,
+pub struct Blob {
+    data: Vec<isize>,
+    diff: Vec<isize>,
     shape: Vec<isize>
 }
 
-impl <T> Blob<T> {
+impl Blob {
 
     /// Creates a new Blob
-    pub fn new() -> Blob<T> {
+    pub fn new() -> Blob {
         Blob::of_shape(vec![0])
     }
 
     /// Creates a new Blob with specified `shape`
-    pub fn of_shape(new_shape: Vec<isize>) -> Blob<T> {
+    pub fn of_shape(new_shape: Vec<isize>) -> Blob {
         let mut blob = Blob {
             data: vec![],
             diff: vec![],
@@ -66,22 +66,22 @@ impl <T> Blob<T> {
     }
 
     /// Returns a pointer to the data of the Blob
-    pub fn cpu_data(&self) -> &Vec<T> {
+    pub fn cpu_data(&self) -> &Vec<isize> {
         &self.data
     }
 
     /// Returns a mutable pointer to the data of the Blob
-    pub fn mutable_cpu_data(&mut self) -> &mut Vec<T> {
+    pub fn mutable_cpu_data(&mut self) -> &mut Vec<isize> {
         &mut self.data
     }
 
     /// Returns a pointer to the diff of the Blob
-    pub fn cpu_diff(&self) -> &Vec<T> {
+    pub fn cpu_diff(&self) -> &Vec<isize> {
         &self.diff
     }
 
     /// Returns a mutable pointer to the diff of the Blob
-    pub fn mutable_cpu_diff(&mut self) -> &mut Vec<T> {
+    pub fn mutable_cpu_diff(&mut self) -> &mut Vec<isize> {
         &mut self.diff
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@
         trivial_casts, trivial_numeric_casts,
         unsafe_code, unused_import_braces, unused_qualifications)]
 
-//! Phloem exposes a universal Blob for machine learning purposes.
-//! This might be used with the Rust Machine Learning Framwork
+//! Phloem exposes a universal/numeric Blob for machine learning purposes.
+//! This might be used with the Rust Machine Learning Framework
 //! [leaf](https://github.com/autumnai/leaf)
 pub use blob::Blob;
 

--- a/tests/blob_spec.rs
+++ b/tests/blob_spec.rs
@@ -7,21 +7,21 @@ mod blod_spec {
 
     #[test]
     fn construction_basic() {
-        let blob: Blob<f32> = Blob::new();
+        let blob: Blob = Blob::new();
         assert_eq!(blob.cpu_data().capacity(), 0);
     }
 
     #[test]
     fn construction_of_shape() {
         let shape = vec![2, 3, 2];
-        let blob: Blob<f32> = Blob::of_shape(shape);
+        let blob: Blob = Blob::of_shape(shape);
         assert_eq!(12, blob.cpu_data().capacity());
     }
 
     #[test]
     fn shape_string() {
         let shape = vec![2, 3, 2];
-        let blob: Blob<f32> = Blob::of_shape(shape);
+        let blob: Blob = Blob::of_shape(shape);
         assert_eq!("2 3 2 (3)", blob.shape_string());
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: Blob is no longer generic. All its attributes now are requiering a signed value. This makes a Blob always usable for neural nets.
