### PR TITLE
feat(interface): expose blob shape and capacity

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -8,7 +8,7 @@ use Numeric;
 pub struct Blob<T: Numeric> {
     data: Vec<T>,
     diff: Vec<T>,
-    shape: Vec<isize>
+    shape: Vec<isize>,
 }
 
 impl <T> Blob<T> where T: Numeric {
@@ -43,6 +43,11 @@ impl <T> Blob<T> where T: Numeric {
         }
     }
 
+    /// Returns the shape of the Blob
+    pub fn shape(&self) -> Vec<isize> {
+        self.shape.clone()
+    }
+
     /// Returns a String representation of the Blobs' `shape`
     ///
     /// The first numbers represent the size of the dimension.
@@ -64,6 +69,11 @@ impl <T> Blob<T> where T: Numeric {
     /// Returns a boolean value whether the Blobs' data is empty or not
     pub fn is_empty(&self) -> bool {
         self.data.len() == 0
+    }
+
+    /// Returns the allocated capacity of the Blob data.
+    pub fn capacity(&self) -> usize {
+        self.data.capacity()
     }
 
     /// Returns a pointer to the data of the Blob

--- a/tests/blob_spec.rs
+++ b/tests/blob_spec.rs
@@ -34,4 +34,28 @@ mod blod_spec {
         let blob: Blob<f32> = Blob::of_shape(shape);
         assert_eq!("2 3 2 (3)", blob.shape_string());
     }
+
+    #[test]
+    fn correct_len() {
+        let shape = vec![2, 3, 2];
+        let mut blob: Blob<f32> = Blob::of_shape(shape);
+        assert_eq!(0, blob.len());
+
+        blob.mutable_cpu_data().push(0f32);
+        assert_eq!(1, blob.len());
+    }
+
+    #[test]
+    fn correct_capacity() {
+        let shape = vec![2, 2, 2, 2];
+        let blob: Blob<f32> = Blob::of_shape(shape);
+        assert_eq!(16, blob.capacity());
+    }
+
+    #[test]
+    fn correct_shape() {
+        let shape = vec![2, 3, 4];
+        let blob: Blob<f32> = Blob::of_shape(shape);
+        assert_eq!(vec![2, 3, 4], blob.shape());
+    }
 }


### PR DESCRIPTION
We need both of these exposed to make dimension checking work in leaf.
